### PR TITLE
Enable a move log

### DIFF
--- a/src/main/scala/model/Board.scala
+++ b/src/main/scala/model/Board.scala
@@ -107,6 +107,13 @@ case class Board(
                        }
   }
 
+  def move(move: Move): Either[String, Board] = {
+    move match {
+      case NormalMove(start, dest) => normalMove(start, dest)
+      case CastleMove(dest) => castle(dest)
+    }
+  }
+
   /**
    * Generate a new board reflecting the board state after the piece at the starting square moves to the destination
    * square.
@@ -115,7 +122,7 @@ case class Board(
    * @param dest  the destination square. The piece must be able to move here.
    * @return the resulting board after a legal move, or an error string if the move is illegal.
    */
-  def move(start: Square, dest: Square): Either[String, Board] = {
+  private def normalMove(start: Square, dest: Square): Either[String, Board] = {
     checkLegalMove(start, dest)
     val piece = pieces(start).updateHasMoved()
     val nextPieces = pieces - start + (dest -> piece)
@@ -141,7 +148,7 @@ case class Board(
    * @param kingDest the square to which the king will move.
    * @return the new board after the king has castled accordingly, or a failure message if the move is not legal.
    */
-  def castle(kingDest: Square): Either[String, Board] = {
+  private def castle(kingDest: Square): Either[String, Board] = {
     // make sure neither king, destination, or in-between square has opposing attackers
     // make sure there are no pieces between king and rook
     if (!Set(3, 7).contains(kingDest.file) || !Set(1, 8).contains(kingDest.rank)) {
@@ -210,7 +217,7 @@ case class Board(
     val normalMoves = pieces.filter(_._2.isColor(turnColor))
       .map(sq_piece => (sq_piece._1, sq_piece._2.getLegalMoves(sq_piece._1, this))).toList
       .flatMap(sq_pieces => sq_pieces._2.map(piece => (sq_pieces._1, piece)))
-      .map(start_dest => move(start_dest._1, start_dest._2).map((NormalMove(start_dest._1, start_dest._2), _)))
+      .map(start_dest => normalMove(start_dest._1, start_dest._2).map((NormalMove(start_dest._1, start_dest._2), _)))
     val castleMoves = List(Square(3, 1), Square(7, 1), Square(3, 8), Square(7, 8))
       .map(dest => castle(dest).map((CastleMove(dest), _)))
     (normalMoves ++ castleMoves)

--- a/src/main/scala/model/Board.scala
+++ b/src/main/scala/model/Board.scala
@@ -37,10 +37,10 @@ object Board {
  * @param enPassant the square, if any, where a pawn may move for en passant.
  */
 case class Board(
-    val pieces: Map[Square, Piece],
-    val turnColor: Color = Color.White,
-    val enPassant: Option[Square] = None
-) {
+                  pieces: Map[Square, Piece],
+                  turnColor: Color = Color.White,
+                  enPassant: Option[Square] = None
+                ) {
 
   override def toString: String = {
     (RankAndFileMin to RankAndFileMax).map(
@@ -202,20 +202,21 @@ case class Board(
   }
 
   /**
-   * Generate the "next board" for every legal move from this board.
+   * Generate all legal next moves and respective updated boards for this board.
    *
-   * @return a collection of the legal successors of this board.
+   * @return a collection of the legal moves and successors of this board.
    */
-  def getSuccessors: Iterable[Board] = {
+  def getNextMoves: Iterable[(Move, Board)] = {
     val normalMoves = pieces.filter(_._2.isColor(turnColor))
       .map(sq_piece => (sq_piece._1, sq_piece._2.getLegalMoves(sq_piece._1, this))).toList
       .flatMap(sq_pieces => sq_pieces._2.map(piece => (sq_pieces._1, piece)))
-      .map(start_dest => move(start_dest._1, start_dest._2))
-    val castleMoves = List(Square(3, 1), Square(7, 1), Square(3, 8), Square(7, 8)).map(castle)
+      .map(start_dest => move(start_dest._1, start_dest._2).map((NormalMove(start_dest._1, start_dest._2), _)))
+    val castleMoves = List(Square(3, 1), Square(7, 1), Square(3, 8), Square(7, 8))
+      .map(dest => castle(dest).map((CastleMove(dest), _)))
     (normalMoves ++ castleMoves)
       .flatMap {
-        case Left(str) => println(str); None //TODO make this optional a la VLOG
-        case Right(b) => Some(b)
+        case Left(error) => println(error); None // TODO make this optional a la VLOG
+        case Right((move, board)) => Some((move, board))
       }
   }
 

--- a/src/main/scala/model/Board.scala
+++ b/src/main/scala/model/Board.scala
@@ -36,7 +36,7 @@ object Board {
  * @param turnColor the color whose turn it is.
  * @param enPassant the square, if any, where a pawn may move for en passant.
  */
-class Board(
+case class Board(
     val pieces: Map[Square, Piece],
     val turnColor: Color = Color.White,
     val enPassant: Option[Square] = None
@@ -234,19 +234,4 @@ class Board(
     pieces.get(square)
   }
 
-  override def hashCode(): Int = {
-    val state = Seq(pieces, turnColor, enPassant)
-    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
-  }
-
-  def canEqual(other: Any): Boolean = other.isInstanceOf[Board]
-
-  override def equals(other: Any): Boolean = other match {
-    case that: Board =>
-      (that canEqual this) &&
-        pieces == that.pieces &&
-        turnColor == that.turnColor &&
-        enPassant == that.enPassant
-    case _ => false
-  }
 }

--- a/src/main/scala/model/Move.scala
+++ b/src/main/scala/model/Move.scala
@@ -1,0 +1,11 @@
+package model
+
+trait Move {
+  // The square where a piece is moved.
+  def destination: Square
+}
+
+case class CastleMove(override val destination: Square) extends Move
+
+case class NormalMove(start: Square, override val destination: Square) extends Move
+

--- a/src/test/scala/model/BoardTest.scala
+++ b/src/test/scala/model/BoardTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testGetAttackers") {
-    val board = new Board(Map(
+    val board = Board(Map(
       Square(1, 1) -> Bishop(Black), Square(1, 4) -> Rook(Black), Square(1, 7) -> Bishop(White),
       Square(2, 5) -> Knight(Black), Square(4, 3) -> King(Black), Square(4, 5) -> King(White),
       Square(4, 6) -> Pawn(Black), Square(5, 3) -> Pawn(White), Square(5, 8) -> Rook(White),
@@ -31,14 +31,14 @@ class BoardTest extends AnyFunSuite with MockFactory {
   test("testIsLegalMove_Ok") {
     val mockPiece = mock[Piece]
     val board =
-      new Board(Map(Square(1, 1) -> mockPiece), White)
+      Board(Map(Square(1, 1) -> mockPiece), White)
     (mockPiece.isColor _).expects(White).returning(true)
     board.checkLegalMove(Square(1, 1), Square(1, 2)) // should not throw
   }
 
   test("testIsLegalMove_NoPiece") {
     val mockPiece = mock[Piece]
-    val board = new Board(Map(Square(1, 1) -> mockPiece), White)
+    val board = Board(Map(Square(1, 1) -> mockPiece), White)
     (mockPiece.isColor _).expects(*).never()
     assertThrows[IllegalStateException] {
       board.checkLegalMove(Square(0, 1), Square(2, 2))
@@ -48,7 +48,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   test("testIsLegalMove_WrongColor") {
     val mockPiece = mock[Piece]
     val board =
-      new Board(Map(Square(1, 1) -> mockPiece), Black)
+      Board(Map(Square(1, 1) -> mockPiece), Black)
     (mockPiece.isColor _).expects(Black).returning(false)
     (mockPiece.color _).expects().returning(White)
     assertThrows[IllegalStateException] {
@@ -59,7 +59,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   test("testIsLegalMove_OOB") {
     val mockPiece = mock[Piece]
     val board =
-      new Board(Map(Square(1, 1) -> mockPiece), White)
+      Board(Map(Square(1, 1) -> mockPiece), White)
     (mockPiece.isColor _).expects(White).returning(true)
     assertThrows[IllegalArgumentException] {
       board.checkLegalMove(Square(1, 1), Square(99, 2))
@@ -68,28 +68,28 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
 
   test("testKingInCheck_true") {
-    val board = new Board(Map(Square(3, 3) -> King(Black), Square(7, 7) -> Bishop(White)))
+    val board = Board(Map(Square(3, 3) -> King(Black), Square(7, 7) -> Bishop(White)))
     assertResult(true) {
       board.kingInCheck(Black)
     }
   }
 
   test("testKingInCheck_false") {
-    val board = new Board(Map(Square(3, 3) -> King(Black), Square(7, 6) -> Bishop(White)))
+    val board = Board(Map(Square(3, 3) -> King(Black), Square(7, 6) -> Bishop(White)))
     assertResult(false) {
       board.kingInCheck(Black)
     }
   }
 
   test("testKingInCheck_truePawn") {
-    val board = new Board(Map(Square(3, 3) -> King(Black), Square(2, 2) -> Pawn(White)))
+    val board = Board(Map(Square(3, 3) -> King(Black), Square(2, 2) -> Pawn(White)))
     assertResult(true) {
       board.kingInCheck(Black)
     }
   }
 
   test("testCastle_OK") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(White), Square(5, 1) -> King(White), Square(8, 1) -> Rook(White),
         Square(1, 8) -> Rook(White),
@@ -150,7 +150,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_WrongColorKing") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(Black), Square(5, 1) -> King(White)), turnColor = Black)
     assertResult(Left("There is no unmoved Black king at Square(5,1).")) {
@@ -159,7 +159,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_WrongColorRook") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(White), Square(5, 1) -> King(Black)), turnColor = Black)
     assertResult(Left("There is no unmoved Black rook at Square(1,1).")) {
@@ -168,7 +168,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_AlreadyMovedKing") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(Black), Square(5, 1) -> King(Black, hasMoved = true)), turnColor = Black)
     assertResult(Left("There is no unmoved Black king at Square(5,1).")) {
@@ -177,7 +177,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_AlreadyMovedRook") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(Black, hasMoved = true), Square(5, 1) -> King(Black)), turnColor = Black)
     assertResult(Left("There is no unmoved Black rook at Square(1,1).")) {
@@ -186,7 +186,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_PiecesBlocking") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(Black), Square(2, 1) -> Knight(Black), Square(5, 1) -> King(Black)),
       turnColor = Black)
@@ -196,7 +196,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
   }
 
   test("testCastle_PiecesAttacking") {
-    val board = new Board(
+    val board = Board(
       Map(
         Square(1, 1) -> Rook(Black), Square(2, 3) -> Knight(White), Square(5, 1) -> King(Black)),
       turnColor = Black)
@@ -207,16 +207,16 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testMove_OK") {
     val board =
-      new Board(Map(Square(1, 1) -> Pawn(Black)), Black)
+      Board(Map(Square(1, 1) -> Pawn(Black)), Black)
 
-    assertResult(Right(new Board(Map(Square(1, 2) -> Pawn(Black, hasMoved = true)), White))) {
+    assertResult(Right(Board(Map(Square(1, 2) -> Pawn(Black, hasMoved = true)), White))) {
       board.move(Square(1, 1), Square(1, 2))
     }
   }
 
   test("testMove_kingMovingIntoCheck") {
     val board =
-      new Board(Map(Square(1, 1) -> King(Black), Square(2, 2) -> Rook(White)), Black)
+      Board(Map(Square(1, 1) -> King(Black), Square(2, 2) -> Rook(White)), Black)
     assertResult(Left("Move Square(1,1) -> Square(2,1) leaves the king in check.")) {
       board.move(Square(1, 1), Square(2, 1))
     }
@@ -224,7 +224,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testMove_pinnedPiece") {
     val board =
-      new Board(
+      Board(
         Map(Square(1, 1) -> King(Black), Square(2, 2) -> Rook(Black), Square(5, 5) -> Bishop(White)),
         Black)
     assertResult(Left("Move Square(2,2) -> Square(3,2) leaves the king in check.")) {
@@ -235,10 +235,10 @@ class BoardTest extends AnyFunSuite with MockFactory {
   test("testMove_EnPassantWhite") {
     val piece = Pawn(White)
     val board =
-      new Board(Map(Square(1, 1) -> piece), White)
+      Board(Map(Square(1, 1) -> piece), White)
     assertResult(
       Right(
-        new Board(Map(Square(1, 3) -> Pawn(White, hasMoved = true)), turnColor = Black, enPassant = Some(Square(1, 2))))
+        Board(Map(Square(1, 3) -> Pawn(White, hasMoved = true)), turnColor = Black, enPassant = Some(Square(1, 2))))
     ) {
       board.move(Square(1, 1), Square(1, 3))
     }
@@ -247,12 +247,12 @@ class BoardTest extends AnyFunSuite with MockFactory {
   test("testMove_EnPassantBlack") {
     val piece = Pawn(Black)
     val board =
-      new Board(Map(Square(8, 8) -> piece), Black)
+      Board(Map(Square(8, 8) -> piece), Black)
 
     val result =
       assertResult(
         Right(
-          new Board(Map(Square(8, 6) -> Pawn(Black, hasMoved = true)), turnColor = White,
+          Board(Map(Square(8, 6) -> Pawn(Black, hasMoved = true)), turnColor = White,
             enPassant = Some(Square(8, 7))))
       ) {
         board.move(Square(8, 8), Square(8, 6))
@@ -261,28 +261,28 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testGetSucessors_NoCurrentCheck") {
     val board =
-      new Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = White)
 
     val expectedBoards: Set[Board] = Set(
-      new Board(Map(Square(8, 2) -> King(White, hasMoved = true), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(8, 2) -> King(White, hasMoved = true), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = Black),
-      new Board(Map(Square(8, 1) -> King(White, hasMoved = true), Square(5, 2) -> Bishop(Black),
+      Board(Map(Square(8, 1) -> King(White, hasMoved = true), Square(5, 2) -> Bishop(Black),
         Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = Black),
-      new Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 3) -> Queen(White, hasMoved = true),
         Square(8, 3) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = Black),
-      new Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 4) -> Queen(White, hasMoved = true),
         Square(8, 3) -> Pawn(White, hasMoved = true)), turnColor = Black),
-      new Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 4) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = Black),
-      new Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(7, 4) -> Pawn(White, hasMoved = true)),
         turnColor = Black)
     )
@@ -293,23 +293,23 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testGetSucessors_InCheckAlready") {
     val board =
-      new Board(Map(Square(7, 1) -> King(Black), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
+      Board(Map(Square(7, 1) -> King(Black), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = Black)
 
     val expectedBoards: Set[Board] = Set(
-      new Board(
+      Board(
         Map(Square(6, 2) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = White),
-      new Board(
+      Board(
         Map(Square(8, 2) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = White),
-      new Board(
+      Board(
         Map(Square(8, 1) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = White),
-      new Board(
+      Board(
         Map(Square(6, 1) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = White),
-      new Board(Map(Square(7, 1) -> King(Black), Square(7, 3) -> Queen(Black, hasMoved = true)),
+      Board(Map(Square(7, 1) -> King(Black), Square(7, 3) -> Queen(Black, hasMoved = true)),
         turnColor = White) // despite her central position, the queen can only move to remove the checking rook
     )
     assertResult(expectedBoards) {
@@ -319,24 +319,24 @@ class BoardTest extends AnyFunSuite with MockFactory {
 
   test("testGetSucessors_WithCastles") {
     val board =
-      new Board(Map(Square(5, 1) -> King(White), Square(8, 1) -> Rook(White), Square(8, 2) -> Rook(Black),
+      Board(Map(Square(5, 1) -> King(White), Square(8, 1) -> Rook(White), Square(8, 2) -> Rook(Black),
         Square(4, 8) -> Rook(Black)), // black rooks thrown in to keep the available moves limited
         turnColor = White)
 
     val expectedBoards: Set[Board] = Set(
-      new Board(
+      Board(
         Map(Square(7, 1) -> King(White, hasMoved = true), Square(6, 1) -> Rook(White, hasMoved = true),
           Square(8, 2) -> Rook(Black), Square(4, 8) -> Rook(Black)), turnColor = Black),
-      new Board(
+      Board(
         Map(Square(6, 1) -> King(White, hasMoved = true), Square(8, 1) -> Rook(White), Square(8, 2) -> Rook(Black),
           Square(4, 8) -> Rook(Black)), turnColor = Black),
-      new Board(
+      Board(
         Map(Square(5, 1) -> King(White), Square(6, 1) -> Rook(White, hasMoved = true), Square(8, 2) -> Rook(Black),
           Square(4, 8) -> Rook(Black)), turnColor = Black),
-      new Board(
+      Board(
         Map(Square(5, 1) -> King(White), Square(7, 1) -> Rook(White, hasMoved = true), Square(8, 2) -> Rook(Black),
           Square(4, 8) -> Rook(Black)), turnColor = Black),
-      new Board(
+      Board(
         Map(Square(5, 1) -> King(White), Square(8, 2) -> Rook(White, hasMoved = true), Square(4, 8) -> Rook(Black)),
         turnColor = Black)
     )

--- a/src/test/scala/model/BoardTest.scala
+++ b/src/test/scala/model/BoardTest.scala
@@ -249,7 +249,6 @@ class BoardTest extends AnyFunSuite with MockFactory {
     val board =
       Board(Map(Square(8, 8) -> piece), Black)
 
-    val result =
       assertResult(
         Right(
           Board(Map(Square(8, 6) -> Pawn(Black, hasMoved = true)), turnColor = White,
@@ -265,29 +264,31 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
         Square(7, 4) -> Rook(Black)), turnColor = White)
 
-    val expectedBoards: Set[Board] = Set(
-      Board(Map(Square(8, 2) -> King(White, hasMoved = true), Square(8, 1) -> Knight(Black),
-        Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
-        Square(7, 4) -> Rook(Black)), turnColor = Black),
-      Board(Map(Square(8, 1) -> King(White, hasMoved = true), Square(5, 2) -> Bishop(Black),
-        Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
-        Square(7, 4) -> Rook(Black)), turnColor = Black),
-      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+    val expectedMoves: Set[(Move, Board)] = Set(
+      (NormalMove(Square(7, 1), Square(8, 2)),
+        Board(Map(Square(8, 2) -> King(White, hasMoved = true), Square(8, 1) -> Knight(Black),
+          Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
+          Square(7, 4) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(7, 1), Square(8, 1)),
+        Board(Map(Square(8, 1) -> King(White, hasMoved = true), Square(5, 2) -> Bishop(Black),
+          Square(7, 2) -> Queen(White), Square(8, 3) -> Pawn(White, hasMoved = true),
+          Square(7, 4) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(7, 2), Square(7, 3)), Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 3) -> Queen(White, hasMoved = true),
         Square(8, 3) -> Pawn(White, hasMoved = true),
-        Square(7, 4) -> Rook(Black)), turnColor = Black),
-      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+        Square(7, 4) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(7, 2), Square(7, 4)), Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 4) -> Queen(White, hasMoved = true),
-        Square(8, 3) -> Pawn(White, hasMoved = true)), turnColor = Black),
-      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+        Square(8, 3) -> Pawn(White, hasMoved = true)), turnColor = Black)),
+      (NormalMove(Square(8, 3), Square(8, 4)), Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(8, 4) -> Pawn(White, hasMoved = true),
-        Square(7, 4) -> Rook(Black)), turnColor = Black),
-      Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
+        Square(7, 4) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(8, 3), Square(7, 4)), Board(Map(Square(7, 1) -> King(White), Square(8, 1) -> Knight(Black),
         Square(5, 2) -> Bishop(Black), Square(7, 2) -> Queen(White), Square(7, 4) -> Pawn(White, hasMoved = true)),
-        turnColor = Black)
+        turnColor = Black))
     )
-    assertResult(expectedBoards) {
-      board.getSuccessors.toSet
+    assertResult(expectedMoves) {
+      board.getNextMoves.toSet
     }
   }
 
@@ -296,24 +297,25 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Board(Map(Square(7, 1) -> King(Black), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
         turnColor = Black)
 
-    val expectedBoards: Set[Board] = Set(
-      Board(
+    val expectedMoves: Set[(Move, Board)] = Set(
+      (NormalMove(Square(7, 1), Square(6, 2)), Board(
         Map(Square(6, 2) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
-        turnColor = White),
-      Board(
+        turnColor = White)),
+      (NormalMove(Square(7, 1), Square(8, 2)), Board(
         Map(Square(8, 2) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
-        turnColor = White),
-      Board(
+        turnColor = White)),
+      (NormalMove(Square(7, 1), Square(8, 1)), Board(
         Map(Square(8, 1) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
-        turnColor = White),
-      Board(
+        turnColor = White)),
+      (NormalMove(Square(7, 1), Square(6, 1)), Board(
         Map(Square(6, 1) -> King(Black, hasMoved = true), Square(4, 3) -> Queen(Black), Square(7, 3) -> Rook(White)),
-        turnColor = White),
-      Board(Map(Square(7, 1) -> King(Black), Square(7, 3) -> Queen(Black, hasMoved = true)),
-        turnColor = White) // despite her central position, the queen can only move to remove the checking rook
+        turnColor = White)),
+      (NormalMove(Square(4, 3), Square(7, 3)),
+        Board(Map(Square(7, 1) -> King(Black), Square(7, 3) -> Queen(Black, hasMoved = true)),
+          turnColor = White)) // despite her central position, the queen can only move to remove the checking rook
     )
-    assertResult(expectedBoards) {
-      board.getSuccessors.toSet
+    assertResult(expectedMoves) {
+      board.getNextMoves.toSet
     }
   }
 
@@ -323,25 +325,25 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Square(4, 8) -> Rook(Black)), // black rooks thrown in to keep the available moves limited
         turnColor = White)
 
-    val expectedBoards: Set[Board] = Set(
-      Board(
+    val expectedMoves: Set[(Move, Board)] = Set(
+      (CastleMove(Square(7, 1)), Board(
         Map(Square(7, 1) -> King(White, hasMoved = true), Square(6, 1) -> Rook(White, hasMoved = true),
-          Square(8, 2) -> Rook(Black), Square(4, 8) -> Rook(Black)), turnColor = Black),
-      Board(
+          Square(8, 2) -> Rook(Black), Square(4, 8) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(5, 1), Square(6, 1)), Board(
         Map(Square(6, 1) -> King(White, hasMoved = true), Square(8, 1) -> Rook(White), Square(8, 2) -> Rook(Black),
-          Square(4, 8) -> Rook(Black)), turnColor = Black),
-      Board(
+          Square(4, 8) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(8, 1), Square(6, 1)), Board(
         Map(Square(5, 1) -> King(White), Square(6, 1) -> Rook(White, hasMoved = true), Square(8, 2) -> Rook(Black),
-          Square(4, 8) -> Rook(Black)), turnColor = Black),
-      Board(
+          Square(4, 8) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(8, 1), Square(7, 1)), Board(
         Map(Square(5, 1) -> King(White), Square(7, 1) -> Rook(White, hasMoved = true), Square(8, 2) -> Rook(Black),
-          Square(4, 8) -> Rook(Black)), turnColor = Black),
-      Board(
+          Square(4, 8) -> Rook(Black)), turnColor = Black)),
+      (NormalMove(Square(8, 1), Square(8, 2)), Board(
         Map(Square(5, 1) -> King(White), Square(8, 2) -> Rook(White, hasMoved = true), Square(4, 8) -> Rook(Black)),
-        turnColor = Black)
+        turnColor = Black))
     )
-    assertResult(expectedBoards) {
-      board.getSuccessors.toSet
+    assertResult(expectedMoves) {
+      board.getNextMoves.toSet
     }
   }
 }

--- a/src/test/scala/model/BoardTest.scala
+++ b/src/test/scala/model/BoardTest.scala
@@ -95,7 +95,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Square(1, 8) -> Rook(White),
         Square(5, 8) -> King(White), Square(8, 8) -> Rook(White)), turnColor = White)
 
-    val rank1QueensideResult = board.castle(Square(3, 1))
+    val rank1QueensideResult = board.move(CastleMove(Square(3, 1)))
     rank1QueensideResult.fold(
       _ => fail(), resultBoard => {
         assertResult(Some(King(White, hasMoved = true))) {
@@ -108,7 +108,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
           resultBoard.turnColor
         }
       })
-    val rank1KingsideResult = board.castle(Square(7, 1))
+    val rank1KingsideResult = board.move(CastleMove(Square(7, 1)))
     rank1KingsideResult.fold(
       _ => fail(), resultBoard => {
         assertResult(Some(King(White, hasMoved = true))) {
@@ -121,7 +121,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
           resultBoard.turnColor
         }
       })
-    val rank8QueensideResult = board.castle(Square(3, 8))
+    val rank8QueensideResult = board.move(CastleMove(Square(3, 8)))
     rank8QueensideResult.fold(
       _ => fail(), resultBoard => {
         assertResult(Some(King(White, hasMoved = true))) {
@@ -134,7 +134,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
           resultBoard.turnColor
         }
       })
-    val rank8KingsideResult = board.castle(Square(7, 8))
+    val rank8KingsideResult = board.move(CastleMove(Square(7, 8)))
     rank8KingsideResult.fold(
       _ => fail(), resultBoard => {
         assertResult(Some(King(White, hasMoved = true))) {
@@ -154,7 +154,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Map(
         Square(1, 1) -> Rook(Black), Square(5, 1) -> King(White)), turnColor = Black)
     assertResult(Left("There is no unmoved Black king at Square(5,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -163,7 +163,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Map(
         Square(1, 1) -> Rook(White), Square(5, 1) -> King(Black)), turnColor = Black)
     assertResult(Left("There is no unmoved Black rook at Square(1,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -172,7 +172,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Map(
         Square(1, 1) -> Rook(Black), Square(5, 1) -> King(Black, hasMoved = true)), turnColor = Black)
     assertResult(Left("There is no unmoved Black king at Square(5,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -181,7 +181,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Map(
         Square(1, 1) -> Rook(Black, hasMoved = true), Square(5, 1) -> King(Black)), turnColor = Black)
     assertResult(Left("There is no unmoved Black rook at Square(1,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -191,7 +191,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Square(1, 1) -> Rook(Black), Square(2, 1) -> Knight(Black), Square(5, 1) -> King(Black)),
       turnColor = Black)
     assertResult(Left("There are pieces between the king at Square(5,1) and the rook at Square(1,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -201,7 +201,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Square(1, 1) -> Rook(Black), Square(2, 3) -> Knight(White), Square(5, 1) -> King(Black)),
       turnColor = Black)
     assertResult(Left("The king cannot safely move from Square(5,1) to Square(3,1).")) {
-      board.castle(Square(3, 1))
+      board.move(CastleMove(Square(3, 1)))
     }
   }
 
@@ -210,7 +210,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Board(Map(Square(1, 1) -> Pawn(Black)), Black)
 
     assertResult(Right(Board(Map(Square(1, 2) -> Pawn(Black, hasMoved = true)), White))) {
-      board.move(Square(1, 1), Square(1, 2))
+      board.move(NormalMove(Square(1, 1), Square(1, 2)))
     }
   }
 
@@ -218,7 +218,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
     val board =
       Board(Map(Square(1, 1) -> King(Black), Square(2, 2) -> Rook(White)), Black)
     assertResult(Left("Move Square(1,1) -> Square(2,1) leaves the king in check.")) {
-      board.move(Square(1, 1), Square(2, 1))
+      board.move(NormalMove(Square(1, 1), Square(2, 1)))
     }
   }
 
@@ -228,7 +228,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
         Map(Square(1, 1) -> King(Black), Square(2, 2) -> Rook(Black), Square(5, 5) -> Bishop(White)),
         Black)
     assertResult(Left("Move Square(2,2) -> Square(3,2) leaves the king in check.")) {
-      board.move(Square(2, 2), Square(3, 2))
+      board.move(NormalMove(Square(2, 2), Square(3, 2)))
     }
   }
 
@@ -240,7 +240,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
       Right(
         Board(Map(Square(1, 3) -> Pawn(White, hasMoved = true)), turnColor = Black, enPassant = Some(Square(1, 2))))
     ) {
-      board.move(Square(1, 1), Square(1, 3))
+      board.move(NormalMove(Square(1, 1), Square(1, 3)))
     }
   }
 
@@ -254,7 +254,7 @@ class BoardTest extends AnyFunSuite with MockFactory {
           Board(Map(Square(8, 6) -> Pawn(Black, hasMoved = true)), turnColor = White,
             enPassant = Some(Square(8, 7))))
       ) {
-        board.move(Square(8, 8), Square(8, 6))
+        board.move(NormalMove(Square(8, 8), Square(8, 6)))
       }
   }
 


### PR DESCRIPTION
Make it so the successor fn also returns the move associated with each "next state".